### PR TITLE
Expose rails service port

### DIFF
--- a/docker-compose.production.yaml
+++ b/docker-compose.production.yaml
@@ -13,7 +13,7 @@ services:
       - postgres
       - redis
     ports:
-      - '127.0.0.1:3000:3000'
+      - '3000:3000'
     environment:
       - NODE_ENV=production
       - RAILS_ENV=production


### PR DESCRIPTION
## Summary
- expose Rails service on host port 3000 in production compose

## Testing
- `docker compose -f docker-compose.production.yaml config` *(fails: command not found: docker)*
- `docker compose -f docker-compose.production.yaml up -d rails` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68aba4e4aa8c833185ae4a0bd47009c3