### PR TITLE
chore: install libyaml in Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,6 +33,8 @@ RUN apk update && apk add --no-cache \
   postgresql-client \
   git \
   curl \
+  libyaml-dev \
+  libyaml \
   xz \
   && mkdir -p /var/app \
   && gem install bundler
@@ -128,6 +130,7 @@ RUN apk update && apk add --no-cache \
   imagemagick \
   git \
   vips \
+  libyaml \
   && gem install bundler
 
 COPY --from=node /usr/local/bin/node /usr/local/bin/


### PR DESCRIPTION
## Summary
- include libyaml-dev and libyaml in pre-builder stage
- add libyaml runtime dependency in final stage

## Testing
- `bundle exec rubocop` *(fails: command not found)*
- `pnpm eslint` *(fails: missing eslint.config.js)*
- `docker build -f docker/Dockerfile .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac95a1f1e88331b83cfdb6e6cad769