### PR TITLE
Use force when removing .gitignore in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -95,7 +95,7 @@ RUN git rev-parse HEAD > /app/.git_sha
 RUN rm -rf /gems/ruby/3.4.0/cache/*.gem \
   && find /gems/ruby/3.4.0/gems/ \( -name "*.c" -o -name "*.o" \) -delete \
   && rm -rf .git \
-  && rm .gitignore
+  && rm -f .gitignore
 
 # final build stage
 FROM ruby:3.4.4-alpine3.21


### PR DESCRIPTION
## Summary
- use `rm -f .gitignore` in Dockerfile to avoid failure when file missing

## Testing
- `pnpm eslint` *(fails: ESLint couldn't find config)*
- `bundle exec rubocop` *(fails: command not found: bundle)*
- `docker build -t chathub360_kanban-test -f docker/Dockerfile .` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68acfbd069cc833185b07f4db500f916