### PR TITLE
Export dummy env vars for assets precompile

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -30,6 +30,7 @@ Rails.application.configure do
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
+  config.assets.initialize_on_precompile = false
 
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -84,7 +84,8 @@ RUN mkdir -p /app/log
 
 # generate production assets if production environment
 RUN if [ "$RAILS_ENV" = "production" ]; then \
-  SECRET_KEY_BASE=precompile_placeholder RAILS_LOG_TO_STDOUT=enabled bundle exec rake assets:precompile \
+  export SECRET_KEY_BASE=precompile_placeholder DATABASE_URL=postgres://postgres@localhost:5432/postgres && \
+  RAILS_LOG_TO_STDOUT=enabled bundle exec rake assets:precompile \
   && rm -rf spec node_modules tmp/cache; \
   fi
 


### PR DESCRIPTION
## Summary
- ensure Docker image exports dummy SECRET_KEY_BASE and DATABASE_URL before asset compilation
- avoid initializing Rails on assets precompile in production

## Testing
- `bundle install` *(fails: command not found)*
- `sudo apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ada54559a883319d0e4701fb8f284d