### PR TITLE
chore(docker): disable husky during pnpm install

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -74,7 +74,7 @@ RUN if [ "$RAILS_ENV" = "production" ]; then \
   fi
 
 COPY package.json pnpm-lock.yaml ./
-RUN pnpm i
+RUN HUSKY=0 pnpm install
 
 COPY . /app
 


### PR DESCRIPTION
## Summary
- disable Husky git hooks during pnpm install in Docker build

## Testing
- `pnpm eslint`
- `bundle exec rubocop` *(fails: command not found: bundle)*
- `pnpm test app/javascript/shared/helpers/specs/DateHelper.spec.js`


------
https://chatgpt.com/codex/tasks/task_e_68ada544b26c8331ace0c6c483fea4ad